### PR TITLE
Add functionality to retrieve data from state to set initial

### DIFF
--- a/src/angular/app/core/state-management/enrollment-state.ts
+++ b/src/angular/app/core/state-management/enrollment-state.ts
@@ -1,4 +1,4 @@
-import { Injectable, Signal } from '@angular/core';
+import { computed, Injectable, Signal } from '@angular/core';
 
 import { State } from '../services/state';
 
@@ -15,15 +15,7 @@ export class EnrollmentState extends State<Enrollment> {
   readonly #COURSES_KEY_NAME: Extract<keyof Enrollment, 'courses'> = 'courses';
 
   constructor() {
-    super({
-      student: {
-        sis: '',
-        password: '',
-        birthday: '',
-      },
-      courses: [],
-      codes: [],
-    });
+    super({} as Enrollment);
   }
 
   public setStudent(student: Student): void {
@@ -53,6 +45,14 @@ export class EnrollmentState extends State<Enrollment> {
 
   public selectCourses(): Signal<Course[]> {
     return this.select(this.#COURSES_KEY_NAME);
+  }
+
+  public selectEnrollment(): Signal<Enrollment> {
+    return computed(() => ({
+      student: this.selectStudent()(),
+      codes: this.selectCodes()(),
+      courses: this.selectCourses()(),
+    }));
   }
 
   public deleteCourse(code: string): void {

--- a/src/angular/app/modules/enrollment-setup/components/codes-form/codes-form.ts
+++ b/src/angular/app/modules/enrollment-setup/components/codes-form/codes-form.ts
@@ -1,14 +1,37 @@
-import {Component, model, ModelSignal} from '@angular/core';
-import {FormGroup, ReactiveFormsModule} from '@angular/forms';
+import {
+  Component,
+  input,
+  InputSignal,
+  model,
+  ModelSignal,
+  OnInit,
+} from '@angular/core';
+import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 
 @Component({
   selector: 'codes-form',
-  imports: [
-    ReactiveFormsModule
-  ],
+  imports: [ReactiveFormsModule],
   templateUrl: './codes-form.html',
-  styleUrl: './codes-form.scss'
+  styleUrl: './codes-form.scss',
 })
-export class CodesForm {
-  public form: ModelSignal<FormGroup> = model.required();
+export class CodesForm implements OnInit {
+  codes: InputSignal<string[] | undefined> = input();
+  form: ModelSignal<FormGroup> = model.required();
+
+  ngOnInit(): void {
+    this.#initialize();
+  }
+
+  #initialize(): void {
+    const codes: string[] | undefined = this.codes();
+    if (codes?.length) {
+      this.form().setValue({
+        codeOne: codes[0],
+        codeTwo: codes[1],
+        codeThree: codes[2],
+        codeFour: codes[3],
+        codeFive: codes[4],
+      });
+    }
+  }
 }

--- a/src/angular/app/modules/enrollment-setup/components/courses-form/courses-form.ts
+++ b/src/angular/app/modules/enrollment-setup/components/courses-form/courses-form.ts
@@ -1,8 +1,11 @@
 import {
   Component,
   inject,
+  input,
+  InputSignal,
   model,
   ModelSignal,
+  OnInit,
   signal,
   WritableSignal,
 } from '@angular/core';
@@ -15,7 +18,7 @@ import {
 
 import { Course } from '@core/models/course';
 
-import { CourseForm } from '@modules/enrollment-setup/components/course-form/course-form';
+import { CourseForm } from '../../components/course-form/course-form';
 
 @Component({
   selector: 'courses-form',
@@ -23,28 +26,40 @@ import { CourseForm } from '@modules/enrollment-setup/components/course-form/cou
   templateUrl: './courses-form.html',
   styleUrl: './courses-form.scss',
 })
-export class CoursesForm {
-  public form: ModelSignal<FormGroup> = model.required();
+export class CoursesForm implements OnInit {
+  initialCourses: InputSignal<Course[] | undefined> = input();
+  form: ModelSignal<FormGroup> = model.required();
 
   protected courses: WritableSignal<Course[]> = signal([]);
 
   #formBuilder: FormBuilder = inject(FormBuilder);
 
-  public addCourse(course: Course): void {
-    if (this.#alreadyCourseExist(course.code)) return;
-    this.courses.update((prev) => {
-      const courses: Course[] = [...prev, course];
-      this.#updateForm(courses);
-      return courses;
-    });
+  ngOnInit(): void {
+    this.#initialize();
   }
 
-  public removeCourse(code: string): void {
-    this.courses.update((prev) => {
-      const courses: Course[] = prev.filter((course) => course.code !== code);
-      this.#updateForm(courses);
-      return courses;
-    });
+  addCourse(course: Course): void {
+    if (this.#alreadyCourseExist(course.code)) return;
+    const courses: Course[] = [...this.courses(), course];
+    this.#updateCourses(courses);
+  }
+
+  removeCourse(code: string): void {
+    const courses: Course[] = this.courses().filter(
+      (course) => course.code !== code,
+    );
+    this.#updateCourses(courses);
+  }
+
+  #initialize(): void {
+    const courses: Course[] = [...(this.initialCourses() ?? [])];
+    this.courses.set(courses);
+    this.#updateForm(courses);
+  }
+
+  #updateCourses(courses: Course[]): void {
+    this.#updateForm(courses);
+    this.courses.set(courses);
   }
 
   #alreadyCourseExist(code: string): boolean {

--- a/src/angular/app/modules/enrollment-setup/components/user-info-form/user-info-form.ts
+++ b/src/angular/app/modules/enrollment-setup/components/user-info-form/user-info-form.ts
@@ -1,5 +1,14 @@
-import { Component, model, ModelSignal } from '@angular/core';
+import {
+  Component,
+  input,
+  InputSignal,
+  model,
+  ModelSignal,
+  OnInit,
+} from '@angular/core';
 import { FormGroup, ReactiveFormsModule } from '@angular/forms';
+
+import { Student } from '@core/models/student';
 
 @Component({
   selector: 'user-info-form',
@@ -7,6 +16,22 @@ import { FormGroup, ReactiveFormsModule } from '@angular/forms';
   templateUrl: './user-info-form.html',
   styleUrl: './user-info-form.scss',
 })
-export class UserInfoForm {
-  public form: ModelSignal<FormGroup> = model.required();
+export class UserInfoForm implements OnInit {
+  student: InputSignal<Student | undefined> = input();
+  form: ModelSignal<FormGroup> = model.required();
+
+  ngOnInit(): void {
+    this.#initialize();
+  }
+
+  #initialize(): void {
+    const student: Student | undefined = this.student();
+    if (student) {
+      this.form().setValue({
+        sis: student.sis,
+        password: student.password,
+        birthdate: student.birthday,
+      });
+    }
+  }
 }

--- a/src/angular/app/modules/enrollment-setup/components/wizard/wizard.html
+++ b/src/angular/app/modules/enrollment-setup/components/wizard/wizard.html
@@ -1,13 +1,13 @@
 <section class="wizard">
   @switch (currentStep()) {
     @case (USER_INFO_STEP) {
-      <user-info-form [form]="form()"></user-info-form>
+      <user-info-form [student]="enrollment().student" [form]="form()"></user-info-form>
     }
     @case (CODES_STEP) {
-      <codes-form [form]="form()"></codes-form>
+      <codes-form [codes]="enrollment().codes" [form]="form()"></codes-form>
     }
     @case (COURSE_STEP) {
-      <courses-form [form]="form()"></courses-form>
+      <courses-form [initialCourses]="enrollment().courses" [form]="form()"></courses-form>
     }
   }
 

--- a/src/angular/app/modules/enrollment-setup/components/wizard/wizard.ts
+++ b/src/angular/app/modules/enrollment-setup/components/wizard/wizard.ts
@@ -2,6 +2,8 @@ import {
   Component,
   computed,
   inject,
+  input,
+  InputSignal,
   output,
   OutputEmitterRef,
   Signal,
@@ -10,13 +12,17 @@ import {
 } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 
+import { Course } from '@core/models/course';
+import { Enrollment } from '@core/models/enrollment';
+
 import { CodesFormBuilder } from '../../use-cases/codes-form-builder';
 import { CoursesFormBuilder } from '../../use-cases/courses-form-builder';
 import { EnrollmentSetupFormBuilder } from '../../use-cases/enrollment-setup-form-builder';
 import { UserInfoFormBuilder } from '../../use-cases/user-info-form-builder';
 
-import { EnrollmentStep, UserInfoStep } from '../../types/enrollment-step';
+import { UserInfoStep } from '../../types/enrollment-step';
 import { EnrollmentStepType } from '../../types/enums/enrollment-step-type';
+import { StepSubmitEvent } from '../../types/step-submit-event';
 
 import { CodesForm } from '../codes-form/codes-form';
 import { CoursesForm } from '../courses-form/courses-form';
@@ -35,7 +41,8 @@ import { UserInfoForm } from '../user-info-form/user-info-form';
   styleUrl: './wizard.scss',
 })
 export class Wizard {
-  public eventSubmitStepData: OutputEmitterRef<EnrollmentStep> = output();
+  enrollment: InputSignal<Enrollment> = input.required();
+  eventSubmitStepData: OutputEmitterRef<StepSubmitEvent> = output();
 
   protected currentStep: WritableSignal<number> = signal(1);
   protected form: Signal<FormGroup> = computed((): FormGroup => {
@@ -53,41 +60,51 @@ export class Wizard {
 
   #formBuilder: EnrollmentSetupFormBuilder = inject(EnrollmentSetupFormBuilder);
 
-  public handleSubmitStepData(): void {
+  protected handleSubmitStepData(shouldFinish?: boolean): void {
     if (this.currentStep() === this.USER_INFO_STEP) {
       this.eventSubmitStepData.emit({
-        ...(this.form().value as UserInfoStep),
-        type: EnrollmentStepType.USER_INFO,
+        data: {
+          ...(this.form().value as UserInfoStep),
+          type: EnrollmentStepType.USER_INFO,
+        },
+        shouldFinish: !!shouldFinish,
       });
       return;
     }
 
     if (this.currentStep() === this.CODES_STEP) {
       this.eventSubmitStepData.emit({
-        type: EnrollmentStepType.CODES,
-        codes: Object.values(this.form().value),
+        data: {
+          type: EnrollmentStepType.CODES,
+          codes: Object.values(this.form().value),
+        },
+        shouldFinish: !!shouldFinish,
       });
       return;
     }
 
     this.eventSubmitStepData.emit({
-      type: EnrollmentStepType.COURSES,
-      courses: Object.values(this.form().value),
+      data: {
+        type: EnrollmentStepType.COURSES,
+        courses: [...(this.form().value.courses as Course[])],
+      },
+      shouldFinish: !!shouldFinish,
     });
   }
 
-  public nextStep(): void {
+  protected nextStep(): void {
     if (this.currentStep() === this.TOTAL_STEPS) return;
     this.handleSubmitStepData();
     this.currentStep.update((prev) => prev + 1);
   }
 
-  public previousStep(): void {
+  protected previousStep(): void {
     if (this.currentStep() === 1) return;
+    this.handleSubmitStepData();
     this.currentStep.update((prev) => prev - 1);
   }
 
-  public continueProcess(): void {
-    this.handleSubmitStepData();
+  protected continueProcess(): void {
+    this.handleSubmitStepData(true);
   }
 }

--- a/src/angular/app/modules/enrollment-setup/containers/enrollment-setup-container/enrollment-setup-container.html
+++ b/src/angular/app/modules/enrollment-setup/containers/enrollment-setup-container/enrollment-setup-container.html
@@ -1,1 +1,1 @@
-<wizard (eventSubmitStepData)="handleSubmitStepData($event)"></wizard>
+<wizard [enrollment]="enrollment()" (eventSubmitStepData)="handleSubmitStepData($event)"></wizard>

--- a/src/angular/app/modules/enrollment-setup/containers/enrollment-setup-container/enrollment-setup-container.ts
+++ b/src/angular/app/modules/enrollment-setup/containers/enrollment-setup-container/enrollment-setup-container.ts
@@ -1,12 +1,14 @@
-import { Component, inject } from '@angular/core';
+import { Component, inject, OnInit, signal, Signal } from '@angular/core';
 import { Router } from '@angular/router';
 
+import { Enrollment } from '@core/models/enrollment';
+
 import { EnrollmentStep } from '../../types/enrollment-step';
-import { EnrollmentStepType } from '../../types/enums/enrollment-step-type';
 
 import { EnrollmentSetupFacade } from '../../facades/enrollment-setup.facade';
 
 import { Wizard } from '../../components/wizard/wizard';
+import { StepSubmitEvent } from '@modules/enrollment-setup/types/step-submit-event';
 
 @Component({
   selector: 'enrollment-setup-container',
@@ -14,7 +16,9 @@ import { Wizard } from '../../components/wizard/wizard';
   templateUrl: './enrollment-setup-container.html',
   styleUrl: './enrollment-setup-container.scss',
 })
-export class EnrollmentSetupContainer {
+export class EnrollmentSetupContainer implements OnInit {
+  protected enrollment: Signal<Enrollment> = signal({} as Enrollment);
+
   readonly #enrollmentSetupFacade: EnrollmentSetupFacade = inject(
     EnrollmentSetupFacade,
   );
@@ -23,11 +27,21 @@ export class EnrollmentSetupContainer {
   // todo: rename after defining the next page name
   readonly #URL: string = '';
 
-  protected async handleSubmitStepData(data: EnrollmentStep): Promise<void> {
-    this.#enrollmentSetupFacade.saveStepInformation(data);
+  ngOnInit(): void {
+    this.#initialize();
+  }
 
-    if (data.type === EnrollmentStepType.COURSES) {
+  protected async handleSubmitStepData(
+    stepEvent: StepSubmitEvent,
+  ): Promise<void> {
+    this.#enrollmentSetupFacade.saveStepInformation(stepEvent.data);
+
+    if (stepEvent.shouldFinish) {
       await this.#router.navigate([this.#URL]);
     }
+  }
+
+  #initialize(): void {
+    this.enrollment = this.#enrollmentSetupFacade.getEnrollment();
   }
 }

--- a/src/angular/app/modules/enrollment-setup/facades/enrollment-setup.facade.ts
+++ b/src/angular/app/modules/enrollment-setup/facades/enrollment-setup.facade.ts
@@ -1,5 +1,6 @@
-import { inject, Injectable } from '@angular/core';
+import { inject, Injectable, Signal } from '@angular/core';
 
+import { Enrollment } from '@core/models/enrollment';
 import { EnrollmentState } from '@core/state-management/enrollment-state';
 
 import { EnrollmentStep } from '../types/enrollment-step';
@@ -25,5 +26,9 @@ export class EnrollmentSetupFacade {
     }
 
     this.#store.setCourses(stepData.courses);
+  }
+
+  getEnrollment(): Signal<Enrollment> {
+    return this.#store.selectEnrollment();
   }
 }

--- a/src/angular/app/modules/enrollment-setup/types/step-submit-event.ts
+++ b/src/angular/app/modules/enrollment-setup/types/step-submit-event.ts
@@ -1,0 +1,6 @@
+import { EnrollmentStep } from './enrollment-step';
+
+export interface StepSubmitEvent {
+  data: EnrollmentStep;
+  shouldFinish: boolean;
+}


### PR DESCRIPTION
## Summary
This PR adds functionality to retrieve data from the state and use it to initialize the enrollment flow.

## Changes
- Added a method to `enrollment-state` to get the complete state (student, codes, courses).
- Updated each step form to receive and set initial data from the state.
- Updated the facade to expose the new functionality.
- Added the `StepSubmitEvent`.